### PR TITLE
Fix storage of invalid json descriptions

### DIFF
--- a/download_dataset.py
+++ b/download_dataset.py
@@ -93,7 +93,7 @@ def parse_desc(desc):
 
     while line_end_index < len(desc):
         if desc[line_end_index:line_end_index+2] == '},':
-            line = desc[line_start_index: line_end_index]
+            line = desc[line_start_index: line_end_index + 2]
             # indent the line
             line = ' ' * indentation + line
             lines.append(line)


### PR DESCRIPTION
parse_desc was generating invalid json as description because it wasn't adding the characters '},'.